### PR TITLE
Add AddProduct

### DIFF
--- a/src/Functions/AddProduct.php
+++ b/src/Functions/AddProduct.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WHMCSAPI\Functions;
+
+class AddProduct
+{
+    public static $action = 'AddProduct';
+
+    public const ATTRIBUTES = [
+        'name', 'gid', 'type', 'stockcontrol', 'qty', 'paytype', 'hidden',
+        'showdomainoptions', 'tax', 'isFeatured', 'proratabilling', 'description',
+        'welcomeemail', 'proratadate', 'proratachargenextmonth', 'subdomain',
+        'autosetup', 'module', 'servergroupid', 'configoption1', 'configoption2',
+        'configoption3', 'configoption4', 'configoption5', 'configoption6',
+        'order', 'pricing',
+    ];
+
+    public const REQUIRED_ATTRIBUTES = [
+        'name', 'gid',
+    ];
+
+    public const ADDITIONAL_REQUIREMENTS = [
+        'gid' => 'numeric',
+        'type' => [
+            'hostingaccount', 'reselleraccount', 'server', 'other',
+        ],
+        'stockcontrol' => 'boolean',
+        'qty' => 'numeric',
+        'hidden' => 'boolean',
+        'showdomainoptions' => 'boolean',
+        'tax' => 'boolean',
+        'isFeatured' => 'boolean',
+        'proratabilling' => 'boolean',
+        'welcomeemail' => 'numeric',
+        'proratadate' => 'numeric',
+        'proratachargenextmonth' => 'numeric',
+        'autosetup' => [
+            '', 'on', 'payment', 'order',
+        ],
+        'order' => 'numeric',
+        'pricing' => 'array',
+    ];
+
+    public const DEFAULTS = [
+        'autosetup' => '',
+    ];
+}

--- a/tests/Functions/AddProductTest.php
+++ b/tests/Functions/AddProductTest.php
@@ -23,7 +23,7 @@ class AddProductTest extends BaseTest
 
     public function testDefaultValuesAreSet()
     {
-        $class = '\\WHMCSAPI\\Functions\\AddPayMethod';
+        $class = '\\WHMCSAPI\\Functions\\AddProduct';
         if (defined($class . '::DEFAULTS')) {
             foreach ($class::DEFAULTS as $attribute => $default) {
                 $this->assertEquals($default, $GLOBALS['whmcsApi']->$attribute);

--- a/tests/Functions/AddProductTest.php
+++ b/tests/Functions/AddProductTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WHMCSAPI\Tests\Functions;
+
+use WHMCSAPI\Exception\NotServiceable;
+use WHMCSAPI\Tests\BaseTest;
+
+class AddProductTest extends BaseTest
+{
+    public function testCanUseUpdateQuoteCommand()
+    {
+        $GLOBALS['whmcsApi']->quoteid = 1;
+        $GLOBALS['whmcsApi']->command('AddProduct');
+        $this->assertEquals('AddProduct', $GLOBALS['whmcsApi']->action);
+    }
+
+    public function testNoProductNameCauseException()
+    {
+        $this->assertNull($GLOBALS['whmcsApi']->name);
+        $this->expectException(NotServiceable::class);
+        $GLOBALS['whmcsApi']->execute();
+    }
+
+    public function testDefaultValuesAreSet()
+    {
+        $class = '\\WHMCSAPI\\Functions\\AddPayMethod';
+        if (defined($class . '::DEFAULTS')) {
+            foreach ($class::DEFAULTS as $attribute => $default) {
+                $this->assertEquals($default, $GLOBALS['whmcsApi']->$attribute);
+            }
+        } else {
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    public function testAttributesCanBeSet()
+    {
+        $GLOBALS['whmcsApi']->gid = 1;
+        $GLOBALS['whmcsApi']->name = 'Test Product';
+        $this->assertEquals(1, $GLOBALS['whmcsApi']->gid);
+        $this->assertEquals('Test Product', $GLOBALS['whmcsApi']->name);
+    }
+
+    public function testCanMakeAPICall()
+    {
+        $result = $GLOBALS['whmcsApi']->execute();
+        $this->assertStringContainsString('{"result":', $result);
+    }
+}


### PR DESCRIPTION
Closes #21 

**There is a known issue in this function** where the product will be created during test, even if the relevant `gid` does not exist.

Reported upstream.